### PR TITLE
Changes for Java9+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target/
 LICENSE.txt
+
+# For all you Mac OS users out there...
+**/.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,10 @@
             <name>OSS Snapshots</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
+    <!-- This deprecated repository on SourceForge is needed as long
+        as directoryService uses the old 2.x ChannelFinderAPI.
+        After switching to cf-client-api version 3.x (on Maven Central),
+        the entry should be removed. -->
         <repository>
             <id>epics</id>
             <name>EPICS Repository</name>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
             <name>OSS Snapshots</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
-        <!-- Temporary - needed for old snapshots of ChannelfinderAPI -->
         <repository>
             <id>epics</id>
             <name>EPICS Repository</name>
@@ -46,7 +45,7 @@
             <version>2.2.0</version>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
 
@@ -67,7 +66,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -85,6 +84,7 @@
                     <descriptors>
                         <descriptor>src/assembly/distribution.xml</descriptor>
                     </descriptors>
+                    <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
                 <executions>
                     <execution>
@@ -128,4 +128,53 @@
 
         </plugins>
     </build>
+
+    <profiles>
+      <profile>
+        <id>java-9+</id>
+        <activation>
+          <jdk>[9,)</jdk>
+        </activation>
+        <!--properties>
+            <maven.compiler.source>1.6</maven.compiler.source>
+            <maven.compiler.target>1.6</maven.compiler.target>
+        </properties-->
+        <build>
+          <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                    <version>3.7</version>
+                  </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                          <additionalOptions>-html5</additionalOptions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Tweaks to pom file due to changed behaviour of the javadoc tool. A change in java source and target version is also needed to compile successfully.